### PR TITLE
Fix invalid pointer expansion on x86-64

### DIFF
--- a/library/templates.h
+++ b/library/templates.h
@@ -1,6 +1,8 @@
 #define VAR_LENGTH      30
 #define VAR_VALUE       20000
 
+void new_var(struct List *,char *, char *);
+
 struct var_node {
     struct Node v_node;
     char v_name[VAR_LENGTH];

--- a/library/text.h
+++ b/library/text.h
@@ -8,3 +8,4 @@
 char *getwhite_or_dash(char *start);
 void upper(char *);
 void lower(char *);
+char *str(int);

--- a/pesquisa/pesquisa.c
+++ b/pesquisa/pesquisa.c
@@ -53,6 +53,8 @@
 #include "../library/queries.h"
 #include "../library/lists.h"
 #include "../library/args.h"
+#include "../library/text.h"
+#include "../library/templates.h"
 
 #define DAYS_NEW 15
 #define MAX_ENTRIES 400


### PR DESCRIPTION
Ensure that char *str(int) is defined, as it may lead to a crash in x86-64.
